### PR TITLE
Spanish policy english changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-# Code for America Slack Policy
-Dated 1/18/17
+# Code for Puerto Rico Slack Policy
 
-* Code for America has a code of conduct that applies to our spaces and events, including this the Code for America Slack channel.This [Code of Conduct can be found here.](https://github.com/codeforamerica/codeofconduct) 
-* Please be aware that Code for America staff may remove users _at will for any reason_ and _will_ remove any user that Code for America staff deems to be violating the Code for Conduct or are being disruptive. 
-* While Slack can be a great place to network, it should not be used to pitch companies or products without prompting. The expection to this is if people are looking for hire talent and are more than welcome to post in the #jobs-for-america channel.   
-* Please note that there are several government staff here in the Slack and any conversations posted in public channels may be subject to a Freedom of Information Act Request. Combined with the size of our Slack, users should treat the Code for America Slack the same way you would a message on a public forum. 
-* To keep pings down, the #announcements channel is admin-only channel. The @channel and @here commands have been disabled. 
-* Feel free to create channels, but keep in mind that Slack channels that are not active for three consecutive months will be archived. 
-* Please note that Code for America is a 501(c)3 non-partisan organization. This particular Slack should not be used for planning partisan activities. For examples of what Code for America considers partisan activity [please see these guidelines:](https://docs.google.com/a/codeforamerica.org/document/d/1MdAkYUV8CqI1szC0O8Erc6_7bHnoPLOPMDw9z_OdFTQ/edit?usp=sharing) 
-* Only staff members of Code for America are allowed to integrate bots, if you would like to add a bot please DM @civicwhitaker. 
-* New users are asked  take a moment to update your profile with your first and last names, title, and organization so people have a better chance of knowing who you are: https://cfa.slack.com/account/profile
-* If you ever have any questions or issues, please feel free to ping @civicwhitaker who moderates our Slack forum. If you are being harrassed on our Slack, you may also contact safespace@codeforamerica.org.
+Como parte de nuestros esfuerzos en crear una comunidad abierta hemos tomado la politica de uso de Slack usada por Code for America y la hemos editado a nuestra necesidades. El proposito es establecer las expectivas de uso de este recurso y de que esta bien o mal en el.
+
+Puede leer la version en español en este enlace.
+
+----
+
+As part of our efforts to make our community a welcoming place we've forked the Code for America Slack policy and made some minor changes to fit our needs. The goal is to set expectations of the use and what is acceptable in our Slack workspace.
+
+You can read the English version in [this link](slack-policy-en.md).

--- a/slack-policy-en.md
+++ b/slack-policy-en.md
@@ -1,13 +1,12 @@
 # Code for Puerto Rico Slack Policy
-Dated 2020-08-08
+Dated 2020-08-11
 
 * Code for Puerto Rico has a code of conduct that applies to our spaces and events, including this the Code for Puerto Rico Slack channel.This [Code of Conduct can be found here.](https://github.com/code4puertorico/codeofconduct).
 * Please be aware that Code for Puerto Rico staff may remove users _at will for any reason_ and _will_ remove any user that Code for Puerto Rico staff deems to be violating the [Code for Conduct](https://github.com/code4puertorico/codeofconduct) or are being disruptive.
 * While Slack can be a great place to network, it should not be used to pitch companies or products without prompting. The expectation to this is if people are looking for hire talent and are more than welcome to post in the #jobs-for-america channel.
-* Please note that there are several government staff here in the Slack and any conversations posted in public channels may be subject to a Freedom of Information Act Request. Combined with the size of our Slack, users should treat the Code for America Slack the same way you would a message on a public forum.
-* To keep pings down, the #announcements channel is admin-only channel. The @channel and @here commands have been disabled.
-* Feel free to create channels, but keep in mind that Slack channels that are not active for three consecutive months will be archived.
-* Please note that Code for Puerto Rico is a part of Code for America, a 501(c)3 non-partisan organization. This particular Slack should not be used for planning partisan activities. For examples of what Code for America considers partisan activity [please see these guidelines:](https://docs.google.com/a/codeforamerica.org/document/d/1MdAkYUV8CqI1szC0O8Erc6_7bHnoPLOPMDw9z_OdFTQ/edit?usp=sharing) 
+* Please note that anybody can join this Slack workspace. Users should treat the Code for Puerto Rico Slack the same way you would a message on a public forum.
+* Feel free to create channels, but keep in mind that Slack channels that are not active for two consecutive months will be archived.
+* Please note that Code for Puerto Rico is a part of Code for America, a 501(c)3 non-partisan organization. This particular Slack should not be used for planning partisan activities. For examples of what Code for America considers partisan activity [please see these guidelines:](https://docs.google.com/a/codeforamerica.org/document/d/1MdAkYUV8CqI1szC0O8Erc6_7bHnoPLOPMDw9z_OdFTQ/edit?usp=sharing)
 * Only staff members of Code for Puerto Rico are allowed to integrate bots, if you would like to add a bot please DM @froi or @alberto.
-* New users are asked  take a moment to update your profile with your first and last names, title, and organization so people have a better chance of knowing who you are: https://code4pr.slack.com/account/profile
-* If you ever have any questions or issues, please feel free to ping @froi or @alberto who moderates our Slack forum. If you are being harassed on our Slack, you may also contact safespace@code4puertorico.org.
+* New users are asked  take a moment to update your profile with your first and last names, What you do, and pronouns so people have a better chance of knowing who you are and how to approach you. You can accomplish this at: https://code4pr.slack.com/account/profile
+* If you ever have any questions or issues, please feel free to ping @froi or @alberto who moderates our Slack forum. If you are being harassed on our Slack or think you've seen a violation of our [Code for Conduct](https://github.com/code4puertorico/codeofconduct), you may also contact coc@code4puertorico.org.

--- a/slack-policy-en.md
+++ b/slack-policy-en.md
@@ -1,0 +1,13 @@
+# Code for Puerto Rico Slack Policy
+Dated 2020-08-08
+
+* Code for Puerto Rico has a code of conduct that applies to our spaces and events, including this the Code for Puerto Rico Slack channel.This [Code of Conduct can be found here.](https://github.com/code4puertorico/codeofconduct).
+* Please be aware that Code for Puerto Rico staff may remove users _at will for any reason_ and _will_ remove any user that Code for Puerto Rico staff deems to be violating the [Code for Conduct](https://github.com/code4puertorico/codeofconduct) or are being disruptive.
+* While Slack can be a great place to network, it should not be used to pitch companies or products without prompting. The expectation to this is if people are looking for hire talent and are more than welcome to post in the #jobs-for-america channel.
+* Please note that there are several government staff here in the Slack and any conversations posted in public channels may be subject to a Freedom of Information Act Request. Combined with the size of our Slack, users should treat the Code for America Slack the same way you would a message on a public forum.
+* To keep pings down, the #announcements channel is admin-only channel. The @channel and @here commands have been disabled.
+* Feel free to create channels, but keep in mind that Slack channels that are not active for three consecutive months will be archived.
+* Please note that Code for Puerto Rico is a part of Code for America, a 501(c)3 non-partisan organization. This particular Slack should not be used for planning partisan activities. For examples of what Code for America considers partisan activity [please see these guidelines:](https://docs.google.com/a/codeforamerica.org/document/d/1MdAkYUV8CqI1szC0O8Erc6_7bHnoPLOPMDw9z_OdFTQ/edit?usp=sharing) 
+* Only staff members of Code for Puerto Rico are allowed to integrate bots, if you would like to add a bot please DM @froi or @alberto.
+* New users are asked  take a moment to update your profile with your first and last names, title, and organization so people have a better chance of knowing who you are: https://code4pr.slack.com/account/profile
+* If you ever have any questions or issues, please feel free to ping @froi or @alberto who moderates our Slack forum. If you are being harassed on our Slack, you may also contact safespace@code4puertorico.org.

--- a/slack-policy-es.md
+++ b/slack-policy-es.md
@@ -1,0 +1,12 @@
+# Code for Puerto Rico Slack Policy
+Dated 2020-08-11
+
+* Code for Puerto Rico tiene un código de conducta que aplica a todos nuestros espacios y eventos, incluyendo nuestro espacio en Slack. Puede leer el [código de conducta aquí.](https://github.com/code4puertorico/codeofconduct).
+* Tengan en cuenta que cualquier integrante del equipo administrativo de Code for Puerto Rico _tiene la autoridad de remover_ y _removera_ a cualquier persona(s) que violente nuestro [código de conducta](https://github.com/code4puertorico/codeofconduct) o que sea disruptivo para la comunidad.
+* Slack es un excelente espacio para colaborar, dicho esto no se debe utilizar para promover compañias o productos sin antes preguntarle al equipo administrativo. La expectativa es que se utilice el canal de #trabajos-jobs para postear oportunidades de empleo.
+* Tengan en cuenta que cualquiera puede unirse a este espacio de Slack. Siempre deben de tratar el espacio de Slack de Code for Puerto Rico igual que a un foro público.
+* Pueden crear los canales que quieran/necesiten. Canales que no tengan actividad en dos meses consecutivos seran borrados. Las excepciones a esta regla son los canales de operaciones de los proyectos oficiales de Code for Puerto Rico.
+* Recuerden que Code for Puerto Rico es parte de Code for America, una organización no-partidista 501(c)3. Este espacio no se debe de usar para la planificación de actividades partidistas. [Por favor lean:](https://docs.google.com/a/codeforamerica.org/document/d/1MdAkYUV8CqI1szC0O8Erc6_7bHnoPLOPMDw9z_OdFTQ/edit?usp=sharing) para ejemplos de que Code for America considera como actividades partidistas.
+* Solo miembros del equipo administrativo de Code for Puerto Rico pueden integrar bots u otros servicios o integraciones. Si quieren añadir un bot o integración envien un mensaje privado (DM) a @froi o @alberto.
+* Por favor tomen un momento para completar su perfil con su nombre, que hacen (What I do y como quieren ser identificado (pronombres / pronouns). Esto permite que otros miembros conoscan quien eres y como hacer cualquier acercamiento. Pueden hacer estos cambios en: https://code4pr.slack.com/account/profile
+* Para cualquier pregunta o problema, por favor contacta por DM a @froi o @alberto. Si sientes algún acoso o vez una violación a nuestro [código de conducta aquí.](https://github.com/code4puertorico/codeofconduct) en nuestro espacio de Slack puedes contactar a coc@code4puertorico.org.


### PR DESCRIPTION
# What's in this PR

- I've added the initial test for the Spanish version of our Slack policy.
- I've edited some of the test in the English version to match the Spanish policy and to better describe the Code for Puerto Rico use of Slack.
- I've added some text to the English version to match the Spanish policy and to better describe the Code for Puerto Rico use of Slack.